### PR TITLE
Password changing notification issue on new member

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -907,6 +907,7 @@ class Member extends DataObject
             && $this->isChanged('Password')
             && $this->record['Password']
             && static::config()->get('notify_password_change')
+            && $this->isInDB()
         ) {
             Email::create()
                 ->setHTMLTemplate('SilverStripe\\Control\\Email\\ChangePasswordEmail')


### PR DESCRIPTION
With `notify_password_change = true`, new member is receiving notification email regarding password changing when they should not.